### PR TITLE
Fix theme token overrides and add popover colors

### DIFF
--- a/client/src/styles/globals.css
+++ b/client/src/styles/globals.css
@@ -9,6 +9,8 @@
     --muted-fg: 217 19% 27%;
     --card: 0 0% 100%;
     --card-fg: 222 47% 12%;
+    --popover: 0 0% 100%;
+    --popover-fg: 222 47% 12%;
     --surface: 210 20% 99%;
     --surface-fg: 217 19% 27%;
     --border: 214 17% 82%;
@@ -37,6 +39,8 @@
     --muted-fg: 214 20% 85%;
     --card: 222 47% 14%;
     --card-fg: 210 20% 96%;
+    --popover: 222 47% 16%;
+    --popover-fg: 210 20% 96%;
     --surface: 221 36% 18%;
     --surface-fg: 214 20% 85%;
     --border: 218 18% 26%;

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,7 +36,6 @@
         "@radix-ui/react-toggle": "^1.1.10",
         "@radix-ui/react-toggle-group": "^1.1.11",
         "@radix-ui/react-tooltip": "^1.2.8",
-        "@replit/vite-plugin-shadcn-theme-json": "^0.0.4",
         "@tanstack/react-query": "^5.90.2",
         "better-sqlite3": "^12.4.1",
         "class-variance-authority": "^0.7.1",
@@ -3682,16 +3681,6 @@
         "@jridgewell/trace-mapping": "^0.3.25"
       }
     },
-    "node_modules/@replit/vite-plugin-shadcn-theme-json": {
-      "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/@replit/vite-plugin-shadcn-theme-json/-/vite-plugin-shadcn-theme-json-0.0.4.tgz",
-      "integrity": "sha512-XsDzFUQ9E118LW5m/YNpIiIox92Uph20PZV/D51tGW3cX9LDAa3fAwjU0AKxLKZHMONXiy/PYakqf2FT9nQylg==",
-      "dependencies": {
-        "@sinclair/typebox": "^0.33.17",
-        "colorjs.io": "^0.5.2",
-        "dedent": "^1.5.3"
-      }
-    },
     "node_modules/@rolldown/pluginutils": {
       "version": "1.0.0-beta.38",
       "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.38.tgz",
@@ -4084,12 +4073,6 @@
       "os": [
         "win32"
       ]
-    },
-    "node_modules/@sinclair/typebox": {
-      "version": "0.33.22",
-      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.33.22.tgz",
-      "integrity": "sha512-auUj4k+f4pyrIVf4GW5UKquSZFHJWri06QgARy9C0t9ZTjJLIuNIrr1yl9bWcJWJ1Gz1vOvYN1D+QPaIlNMVkQ==",
-      "license": "MIT"
     },
     "node_modules/@standard-schema/spec": {
       "version": "1.0.0",
@@ -5484,12 +5467,6 @@
         "react-dom": "^18 || ^19 || ^19.0.0-rc"
       }
     },
-    "node_modules/colorjs.io": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/colorjs.io/-/colorjs.io-0.5.2.tgz",
-      "integrity": "sha512-twmVoizEW7ylZSN32OgKdXRmo1qg+wT5/6C3xu5b9QsWzSFAhHLn2xd8ro0diCsKfCj1RdaTP/nrcW+vAoQPIw==",
-      "license": "MIT"
-    },
     "node_modules/combined-stream": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
@@ -5889,20 +5866,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/dedent": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/dedent/-/dedent-1.7.0.tgz",
-      "integrity": "sha512-HGFtf8yhuhGhqO07SV79tRp+br4MnbdjeVxotpn1QBl30pcLLCQjX5b2295ll0fv8RKDKsmWYrl05usHM9CewQ==",
-      "license": "MIT",
-      "peerDependencies": {
-        "babel-plugin-macros": "^3.1.0"
-      },
-      "peerDependenciesMeta": {
-        "babel-plugin-macros": {
-          "optional": true
-        }
       }
     },
     "node_modules/deep-eql": {

--- a/package.json
+++ b/package.json
@@ -50,7 +50,6 @@
     "@radix-ui/react-toggle": "^1.1.10",
     "@radix-ui/react-toggle-group": "^1.1.11",
     "@radix-ui/react-tooltip": "^1.2.8",
-    "@replit/vite-plugin-shadcn-theme-json": "^0.0.4",
     "@tanstack/react-query": "^5.90.2",
     "better-sqlite3": "^12.4.1",
     "class-variance-authority": "^0.7.1",

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -12,6 +12,10 @@ export default {
           DEFAULT: "hsl(var(--card))",
           fg: "hsl(var(--card-fg))",
         },
+        popover: {
+          DEFAULT: "hsl(var(--popover))",
+          fg: "hsl(var(--popover-fg))",
+        },
         surface: {
           DEFAULT: "hsl(var(--surface))",
           fg: "hsl(var(--surface-fg))",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,6 +1,5 @@
 import { defineConfig } from "vitest/config";
 import react from "@vitejs/plugin-react";
-import themePlugin from "@replit/vite-plugin-shadcn-theme-json";
 import path, { dirname } from "path";
 import runtimeErrorOverlay from "@replit/vite-plugin-runtime-error-modal";
 import { fileURLToPath } from "url";
@@ -12,7 +11,6 @@ export default defineConfig({
   plugins: [
     react(),
     runtimeErrorOverlay(),
-    themePlugin(),
     VitePWA({
       registerType: "autoUpdate",
       injectRegister: "auto",


### PR DESCRIPTION
## Summary
- remove the shadcn theme JSON plugin so the runtime no longer overwrites our custom CSS variables
- define popover color tokens in globals.css and expose them through Tailwind
- regenerate the lockfile after dropping the unused theme plugin dependency

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68db87d8d560832ab9f047bfad0898da