### PR TITLE
Improve settings dialog readability

### DIFF
--- a/client/src/components/settings-dialog.tsx
+++ b/client/src/components/settings-dialog.tsx
@@ -30,13 +30,15 @@ export function SettingsDialog({ settings, onSettingsChange }: SettingsDialogPro
           <SettingsIcon className="h-4 w-4" />
         </Button>
       </DialogTrigger>
-      <DialogContent className="sm:max-w-md border border-border bg-card text-muted shadow-sm">
+      <DialogContent className="sm:max-w-md border border-border bg-card text-fg shadow-sm">
         <DialogHeader>
           <DialogTitle className="text-fg">Settings</DialogTitle>
         </DialogHeader>
         <div className="space-y-4 py-4">
           <div className="flex items-center justify-between gap-4">
-            <Label htmlFor="level">Language Level</Label>
+            <Label htmlFor="level" className="text-fg">
+              Language Level
+            </Label>
             <Select
               value={settings.level}
               onValueChange={(value: 'A1' | 'A2' | 'B1' | 'B2' | 'C1' | 'C2') => 
@@ -58,7 +60,9 @@ export function SettingsDialog({ settings, onSettingsChange }: SettingsDialogPro
           </div>
 
           <div className="flex items-center justify-between gap-4">
-            <Label htmlFor="hints">Show Hints</Label>
+            <Label htmlFor="hints" className="text-fg">
+              Show Hints
+            </Label>
             <Switch
               id="hints"
               checked={settings.showHints}
@@ -69,7 +73,9 @@ export function SettingsDialog({ settings, onSettingsChange }: SettingsDialogPro
           </div>
 
           <div className="flex items-center justify-between gap-4">
-            <Label htmlFor="examples">Show Example Sentences</Label>
+            <Label htmlFor="examples" className="text-fg">
+              Show Example Sentences
+            </Label>
             <Switch
               id="examples"
               checked={settings.showExamples}

--- a/client/src/components/ui/switch.tsx
+++ b/client/src/components/ui/switch.tsx
@@ -5,7 +5,7 @@ import { cva, type VariantProps } from "class-variance-authority";
 import { cn } from "@/lib/cn";
 
 const trackStyles = cva(
-  "focus-ring inline-flex shrink-0 cursor-pointer items-center rounded-full border transition-colors duration-200 data-[state=unchecked]:bg-muted data-[state=unchecked]:border-border data-[state=checked]:border-transparent",
+  "focus-ring inline-flex shrink-0 cursor-pointer items-center rounded-full border border-border/70 bg-[hsl(var(--fg)/0.08)] shadow-inner transition-colors duration-200 data-[state=checked]:border-transparent data-[state=checked]:bg-primary",
   {
     variants: {
       size: {


### PR DESCRIPTION
## Summary
- switch the settings dialog content and labels to the foreground color so copy stays legible
- tweak the toggle styling to give the switch track a visible neutral background and clearer checked state

## Testing
- npm run lint *(fails: repository has existing TypeScript configuration errors unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68dc5fb07328832ab7ae1235991d9dfe