### PR TITLE
Update documentation for Postgres-backed workflows

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ Shut down the container with `docker stop gvm-postgres` when you are done.
 - The `useSyncQueue` hook listens to `online` and `visibilitychange` events and flushes queued attempts back to `POST /api/submission`.
 - Each device receives a persistent `deviceId` stored in `localStorage`; it is sent with every practice submission and stored in `scheduling_state` for priority calculations.
 - `data/words_manual.csv` stores handcrafted rows that supplement the scraped sources.
-- `data/words_all_sources.csv` is regenerated on each `npm run seed` by combining `docs/external/**` with the manual rows, and `data/words_canonical.csv` marks the curated canonical subset. Running `npm run seed` normalises, merges, and upserts that data into SQLite while regenerating `data/packs/*.json` bundles.
+- `data/words_all_sources.csv` is regenerated on each `npm run seed` by combining `docs/external/**` with the manual rows, and `data/words_canonical.csv` marks the curated canonical subset. Running `npm run seed` normalises, merges, and upserts that data into Postgres while regenerating `data/packs/*.json` bundles.
 
 ## Database utilities
 - The schema is managed with Drizzle + Postgres. After editing `db/schema.ts`, run `npm run db:push` to apply migrations using the configured `DATABASE_URL`.

--- a/docs/baseline-kpis.md
+++ b/docs/baseline-kpis.md
@@ -1,6 +1,6 @@
 # Baseline KPI Snapshot (Sept 2025)
 
-This baseline captures current engagement metrics ahead of Phase 1 work. Data was pulled on 26 Sep 2025 using `npx tsx scripts/baseline-kpis.ts`, which queries the production-like SQLite snapshot (`db/data.sqlite`).
+This baseline captures current engagement metrics ahead of Phase 1 work. Data was pulled on 26 Sep 2025 using `npx tsx scripts/baseline-kpis.ts`, which queries the production-like Postgres snapshot backing the Drizzle client.
 
 ## Headline Metrics
 | Metric | Value | Notes |
@@ -26,6 +26,6 @@ Higher levels currently have no recorded activity; this will inform the seeding 
 4. Output a JSON summary to prevent Excel drift; paste the results above.
 
 ## Follow-Up Actions
-- Create synthetic exercise data for levels A2–C1 to stress-test analytics before Phase 1 launch.
+- Create synthetic exercise data for levels A2â€“C1 to stress-test analytics before Phase 1 launch.
 - Define MAU targets once account infrastructure (Phase 3) is scoped; until then track device-level actives.
 - Pipe the script output into a scheduled report (GitHub Actions candidate) so the board receives automatic updates.

--- a/docs/integration-api.md
+++ b/docs/integration-api.md
@@ -4,13 +4,13 @@ GermanVerbMaster now exposes a lightweight REST surface that learning platforms 
 
 ## Authentication
 
-All partner endpoints require an API key passed via the `X-Partner-Key` header. Keys are stored hashed in SQLite. Generate a sandbox key locally with:
+All partner endpoints require an API key passed via the `X-Partner-Key` header. Keys are stored hashed in Postgres (`integration_partners.api_key_hash`). Generate a sandbox key locally with:
 
 ```bash
 npm run integration:create-key -- --name "Acme LMS" --contact "partners@acme.test" --origins "https://sandbox.acme.test,https://lms.acme.test"
 ```
 
-The script prints the plain key for distribution plus an `INSERT` statement for `integration_partners`. Apply the statement to your development database with `sqlite3 db/data.sqlite` or through the Drizzle console. Re-run the command whenever you need to rotate credentials.
+The script prints the plain key for distribution plus an `INSERT` statement for `integration_partners`. Apply the statement to your development database with `psql "$DATABASE_URL" -c "<statement>"` or via the Drizzle console. Re-run the command whenever you need to rotate credentials.
 
 ## Available Endpoints
 
@@ -83,11 +83,11 @@ Returns request analytics for the authenticated partner. Use `windowHours` to co
 ## Sandbox Workflow
 
 1. **Create a partner record** using the script above and apply the SQL snippet.
-2. **Run the stack locally** with `npm run dev`. The Express API listens on `http://localhost:5173` when Vite is active.
+2. **Run the stack locally** with `npm run dev`. The Express API listens on `http://localhost:5000` when Vite is active.
 3. **Call the API** using `curl` or an HTTP client:
    ```bash
    curl -H "X-Partner-Key: <plain-key-from-script>" \
-        "http://localhost:5173/api/partner/drills?level=B1&limit=5"
+        "http://localhost:5000/api/partner/drills?level=B1&limit=5"
    ```
 4. **Inspect analytics** by requesting `/api/partner/usage-summary`. The endpoint reports aggregated totals and the latest 25 requests, which downstream dashboards can ingest.
 5. **Validate embed flows** by wiring the drill payload into your LMS widget. Each prompt already includes localized questions and sample answers for rapid prototyping.

--- a/docs/parts-of-speech-onboarding-guide.md
+++ b/docs/parts-of-speech-onboarding-guide.md
@@ -14,7 +14,7 @@ This guide helps new contributors ramp onto the lexeme-based architecture that n
    npm run seed
    npm run dev
    ```
-4. Visit `http://localhost:5173` and confirm the practice mode switcher exposes Verbs, Nouns, and Adjectives when their feature flags are enabled.
+4. Visit `http://localhost:5000` and confirm the practice mode switcher exposes Verbs, Nouns, and Adjectives when their feature flags are enabled.
 
 ## 2. Understanding the task registry
 - `shared/task-registry.ts` defines the prompt and solution schema for each `taskType` along with default queue caps.

--- a/docs/parts-of-speech-task-19-post-launch-analytics.md
+++ b/docs/parts-of-speech-task-19-post-launch-analytics.md
@@ -19,7 +19,7 @@ Tasks 1–18 introduced the lexeme-centric data model, scheduler, feature flags,
 | Documentation & onboarding assets | Task policies (Task 7), training update (Task 18) | Provide context for operators reviewing dashboards and triaging backlog items.
 
 ## Dashboard Suite
-Three complementary dashboards will be published in Looker (or Metabase equivalent). Each dashboard consumes the shared SQLite snapshot exported to the analytics warehouse nightly via the existing ETL job.
+Three complementary dashboards will be published in Looker (or Metabase equivalent). Each dashboard consumes the shared Postgres snapshot exported to the analytics warehouse nightly via the existing ETL job.
 
 ### 1. POS Adoption & Engagement
 - **Audience:** Product, Content Ops, Executive stakeholders.


### PR DESCRIPTION
## Summary
- clarify that content seeding and integration partner keys target the Postgres database
- update partner integration and onboarding guides with the correct localhost port for the dev server
- refresh analytics docs to reference the Postgres snapshot used by scripts

## Testing
- not run (documentation-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68ed5632c26c8320959511520b708952