### PR TITLE
Validate review queue level hints and refactor practice history handling

### DIFF
--- a/server/routes.ts
+++ b/server/routes.ts
@@ -698,6 +698,82 @@ const recordPracticeSchema = z.object({
   queuedAt: z.string().datetime({ offset: true }).optional(),
 });
 
+type RecordPracticePayload = z.infer<typeof recordPracticeSchema>;
+type PracticeAttemptData = Omit<RecordPracticePayload, "queuedAt">;
+
+function normalizePracticePayload(payload: RecordPracticePayload): {
+  attempt: PracticeAttemptData;
+  practicedAt: Date;
+} {
+  const { queuedAt, ...attempt } = payload;
+  const practicedAt = queuedAt ? new Date(queuedAt) : new Date();
+  if (Number.isNaN(practicedAt.getTime())) {
+    return { attempt, practicedAt: new Date() };
+  }
+  return { attempt, practicedAt };
+}
+
+async function insertPracticeHistoryEntry(
+  attempt: PracticeAttemptData,
+  userId: string | null,
+): Promise<void> {
+  await db.insert(verbPracticeHistory).values({
+    ...attempt,
+    userId,
+  });
+}
+
+async function updateVerbAnalyticsWithAttempt(attempt: PracticeAttemptData): Promise<void> {
+  const analytics = await db.query.verbAnalytics.findFirst({
+    where: eq(verbAnalytics.verb, attempt.verb),
+  });
+
+  if (analytics) {
+    await db
+      .update(verbAnalytics)
+      .set({
+        totalAttempts: sql`${verbAnalytics.totalAttempts} + 1`,
+        correctAttempts:
+          attempt.result === "correct"
+            ? sql`${verbAnalytics.correctAttempts} + 1`
+            : verbAnalytics.correctAttempts,
+        averageTimeSpent: sql`(${verbAnalytics.averageTimeSpent} * ${verbAnalytics.totalAttempts} + ${attempt.timeSpent}) / (${verbAnalytics.totalAttempts} + 1)`,
+        lastPracticedAt: new Date(),
+      })
+      .where(eq(verbAnalytics.verb, attempt.verb));
+    return;
+  }
+
+  await db.insert(verbAnalytics).values({
+    verb: attempt.verb,
+    totalAttempts: 1,
+    correctAttempts: attempt.result === "correct" ? 1 : 0,
+    averageTimeSpent: attempt.timeSpent,
+    lastPracticedAt: new Date(),
+    level: attempt.level,
+  });
+}
+
+async function recordAdaptiveSchedulingAttempt(
+  attempt: PracticeAttemptData,
+  practicedAt: Date,
+  userId: string | null,
+): Promise<void> {
+  try {
+    await srsEngine.recordPracticeAttempt({
+      deviceId: attempt.deviceId,
+      verb: attempt.verb,
+      level: attempt.level,
+      result: attempt.result,
+      timeSpent: attempt.timeSpent,
+      userId,
+      practicedAt,
+    });
+  } catch (error) {
+    console.error("Failed to update adaptive scheduling state:", error);
+  }
+}
+
 function sendError(res: Response, status: number, message: string, code?: string) {
   if (code) {
     return res.status(status).json({ error: message, code });
@@ -2145,10 +2221,9 @@ export function registerRoutes(app: Express): void {
       if (!parsed.success) {
         return sendError(res, 400, "Invalid practice data", "INVALID_INPUT");
       }
-      const { queuedAt, ...data } = parsed.data;
-      const practicedAt = queuedAt ? new Date(queuedAt) : new Date();
+      const { attempt, practicedAt } = normalizePracticePayload(parsed.data);
 
-      const limiterKey = hashKey(`practice-history:${data.deviceId}`);
+      const limiterKey = hashKey(`practice-history:${attempt.deviceId}`);
       const limitCheck = await enforceRateLimit({
         key: limiterKey,
         limit: 30,
@@ -2159,52 +2234,11 @@ export function registerRoutes(app: Express): void {
         return res.status(429).json({ error: "Too many practice submissions", code: "RATE_LIMITED" });
       }
 
-      await db.insert(verbPracticeHistory).values({
-        ...data,
-        userId: getSessionUserId(req.authSession),
-      });
+      const sessionUserId = getSessionUserId(req.authSession);
 
-      const analytics = await db.query.verbAnalytics.findFirst({
-        where: eq(verbAnalytics.verb, data.verb),
-      });
-
-      if (analytics) {
-        await db
-          .update(verbAnalytics)
-          .set({
-            totalAttempts: sql`${verbAnalytics.totalAttempts} + 1`,
-            correctAttempts:
-              data.result === "correct"
-                ? sql`${verbAnalytics.correctAttempts} + 1`
-                : verbAnalytics.correctAttempts,
-            averageTimeSpent: sql`(${verbAnalytics.averageTimeSpent} * ${verbAnalytics.totalAttempts} + ${data.timeSpent}) / (${verbAnalytics.totalAttempts} + 1)`,
-            lastPracticedAt: new Date(),
-          })
-          .where(eq(verbAnalytics.verb, data.verb));
-      } else {
-        await db.insert(verbAnalytics).values({
-          verb: data.verb,
-          totalAttempts: 1,
-          correctAttempts: data.result === "correct" ? 1 : 0,
-          averageTimeSpent: data.timeSpent,
-          lastPracticedAt: new Date(),
-          level: data.level,
-        });
-      }
-
-      try {
-        await srsEngine.recordPracticeAttempt({
-          deviceId: data.deviceId,
-          verb: data.verb,
-          level: data.level,
-          result: data.result,
-          timeSpent: data.timeSpent,
-          userId: getSessionUserId(req.authSession),
-          practicedAt,
-        });
-      } catch (error) {
-        console.error("Failed to update adaptive scheduling state:", error);
-      }
+      await insertPracticeHistoryEntry(attempt, sessionUserId);
+      await updateVerbAnalyticsWithAttempt(attempt);
+      await recordAdaptiveSchedulingAttempt(attempt, practicedAt, sessionUserId);
 
       res.json({ success: true });
     } catch (error) {
@@ -2259,7 +2293,18 @@ export function registerRoutes(app: Express): void {
         return sendError(res, 400, "deviceId is required", "INVALID_DEVICE");
       }
 
-      const levelHint = normalizeStringParam(req.query.level)?.trim() ?? null;
+      const rawLevel = normalizeStringParam(req.query.level);
+      let levelHint: (typeof LEVEL_ORDER)[number] | null = null;
+      if (rawLevel !== undefined) {
+        const trimmedLevel = rawLevel.trim();
+        if (trimmedLevel) {
+          const parsedLevel = levelSchema.safeParse(trimmedLevel);
+          if (!parsedLevel.success) {
+            return sendError(res, 400, "Invalid level parameter", "INVALID_LEVEL");
+          }
+          levelHint = parsedLevel.data;
+        }
+      }
 
       let queue = await srsEngine.fetchQueueForDevice(deviceId);
       if (!queue || srsEngine.isQueueStale(queue)) {

--- a/tests/review-queue-route.test.ts
+++ b/tests/review-queue-route.test.ts
@@ -74,6 +74,17 @@ describe('GET /api/review-queue', () => {
     expect(shadowModeMock.runVerbQueueShadowComparison).not.toHaveBeenCalled();
   });
 
+  it('rejects invalid level hints', async () => {
+    srsEngineMock.isEnabled.mockReturnValue(true);
+
+    const response = await invokeApi('/api/review-queue?deviceId=device-123&level=B3');
+
+    expect(response.status).toBe(400);
+    expect(response.bodyJson).toMatchObject({ code: 'INVALID_LEVEL' });
+    expect(srsEngineMock.fetchQueueForDevice).not.toHaveBeenCalled();
+    expect(srsEngineMock.generateQueueForDevice).not.toHaveBeenCalled();
+  });
+
   it('returns 404 when feature flag disabled', async () => {
     srsEngineMock.isEnabled.mockReturnValue(false);
 


### PR DESCRIPTION
## Summary
- validate the adaptive review queue level hint before using it so malformed values no longer poison scheduling data
- refactor practice history handling into focused helpers and guard against invalid queued timestamps when persisting attempts
- extend the review queue route test coverage to enforce the new validation branch

## Testing
- npm test *(fails: large suite aborted after hitting numerous unrelated baseline failures)*
- npm run check
- npx vitest run tests/review-queue-route.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68ed5f16dbb483209efc1bc2dc3b8bbc