### PR TITLE
Add unique HTML ids across client pages

### DIFF
--- a/client/src/pages/admin.tsx
+++ b/client/src/pages/admin.tsx
@@ -49,6 +49,19 @@ const completeOptions: Array<{ label: string; value: CompleteFilter }> = [
   { label: 'Incomplete', value: 'incomplete' },
 ];
 
+const ADMIN_PAGE_IDS = {
+  page: 'admin-words-page',
+  content: 'admin-words-content',
+  headerSection: 'admin-words-header',
+  filterCard: 'admin-words-filter-card',
+  tokenInput: 'admin-words-token-input',
+  searchInput: 'admin-words-search-input',
+  filterControls: 'admin-words-filter-controls',
+  wordsCard: 'admin-words-table-card',
+  tableContainer: 'admin-words-table-container',
+  pagination: 'admin-words-pagination',
+} as const;
+
 interface EditFieldConfig {
   key:
     | 'level'
@@ -411,12 +424,16 @@ const AdminWordsPage = () => {
   );
 
   return (
-    <AppShell
-      sidebar={sidebar}
-      mobileNav={<MobileNavBar items={navigationItems} />}
-    >
-      <div className="space-y-6">
-        <section className="space-y-4 rounded-3xl border border-border/60 bg-card/85 p-6 shadow-soft shadow-primary/5">
+    <div id={ADMIN_PAGE_IDS.page}>
+      <AppShell
+        sidebar={sidebar}
+        mobileNav={<MobileNavBar items={navigationItems} />}
+      >
+        <div className="space-y-6" id={ADMIN_PAGE_IDS.content}>
+          <section
+            className="space-y-4 rounded-3xl border border-border/60 bg-card/85 p-6 shadow-soft shadow-primary/5"
+            id={ADMIN_PAGE_IDS.headerSection}
+          >
           <div className="space-y-1">
             <p className="text-[11px] font-semibold uppercase tracking-[0.22em] text-muted-foreground">Admin console</p>
             <h1 className="flex items-center gap-2 text-2xl font-semibold text-foreground">
@@ -433,25 +450,33 @@ const AdminWordsPage = () => {
                 variant="secondary"
                 className="rounded-2xl px-5"
                 debugId={`${pageDebugId}-topbar-back-button`}
+                id={`${pageDebugId}-topbar-back-button`}
               >
                 Back to practice
               </Button>
             </Link>
             <Link href="/analytics">
-              <Button className="rounded-2xl px-5" debugId={`${pageDebugId}-topbar-analytics-button`}>
+              <Button
+                className="rounded-2xl px-5"
+                debugId={`${pageDebugId}-topbar-analytics-button`}
+                id={`${pageDebugId}-topbar-analytics-button`}
+              >
                 Open analytics
               </Button>
             </Link>
           </div>
-        </section>
-        <Card className="rounded-3xl border border-border/60 bg-card/85 shadow-lg shadow-primary/5">
+          </section>
+          <Card
+            className="rounded-3xl border border-border/60 bg-card/85 shadow-lg shadow-primary/5"
+            id={ADMIN_PAGE_IDS.filterCard}
+          >
           <CardHeader className="space-y-2">
             <CardTitle>Admin: Words</CardTitle>
             <CardDescription>Review and edit the aggregated lexicon. Filters update the API query in real time.</CardDescription>
           </CardHeader>
           <CardContent className="space-y-6">
             <div className="grid gap-4 lg:grid-cols-2">
-              <div className="space-y-2">
+              <div className="space-y-2" id={ADMIN_PAGE_IDS.tokenInput}>
                 <Label htmlFor="admin-token">Admin token (if configured)</Label>
                 <Input
                   id="admin-token"
@@ -461,7 +486,7 @@ const AdminWordsPage = () => {
                   placeholder="Enter x-admin-token"
                 />
               </div>
-              <div className="space-y-2">
+              <div className="space-y-2" id={ADMIN_PAGE_IDS.searchInput}>
                 <Label htmlFor="search">Search</Label>
                 <Input
                   id="search"
@@ -472,7 +497,7 @@ const AdminWordsPage = () => {
               </div>
             </div>
 
-            <div className="grid gap-4 md:grid-cols-5">
+            <div className="grid gap-4 md:grid-cols-5" id={ADMIN_PAGE_IDS.filterControls}>
               <div className="space-y-2">
                 <Label>Part of speech</Label>
                 <Select value={pos} onValueChange={(value) => setPos(value as Word['pos'] | 'ALL')}>
@@ -512,6 +537,7 @@ const AdminWordsPage = () => {
                     className="flex-1 rounded-2xl"
                     onClick={() => setApprovalFilter('all')}
                     debugId={`${pageDebugId}-approval-filter-all-button`}
+                    id={`${pageDebugId}-approval-filter-all-button`}
                   >
                     All
                   </Button>
@@ -521,6 +547,7 @@ const AdminWordsPage = () => {
                     className="flex-1 rounded-2xl"
                     onClick={() => setApprovalFilter('approved')}
                     debugId={`${pageDebugId}-approval-filter-approved-button`}
+                    id={`${pageDebugId}-approval-filter-approved-button`}
                   >
                     Approved
                   </Button>
@@ -530,6 +557,7 @@ const AdminWordsPage = () => {
                     className="flex-1 rounded-2xl"
                     onClick={() => setApprovalFilter('pending')}
                     debugId={`${pageDebugId}-approval-filter-pending-button`}
+                    id={`${pageDebugId}-approval-filter-pending-button`}
                   >
                     Pending
                   </Button>
@@ -552,9 +580,12 @@ const AdminWordsPage = () => {
               </div>
             </div>
           </CardContent>
-        </Card>
+          </Card>
 
-      <Card className="rounded-3xl border border-border/60 bg-card/85 shadow-lg shadow-primary/5">
+        <Card
+          className="rounded-3xl border border-border/60 bg-card/85 shadow-lg shadow-primary/5"
+          id={ADMIN_PAGE_IDS.wordsCard}
+        >
         <CardHeader>
           <CardTitle>Words</CardTitle>
           <CardDescription>
@@ -595,7 +626,10 @@ const AdminWordsPage = () => {
               </Select>
             </div>
           </div>
-          <div className="max-h-[520px] overflow-auto rounded-3xl border border-border/60">
+          <div
+            className="max-h-[520px] overflow-auto rounded-3xl border border-border/60"
+            id={ADMIN_PAGE_IDS.tableContainer}
+          >
             <Table className="text-xs">
               <TableHeader className="sticky top-0 z-20 bg-card/95 backdrop-blur">
                 <TableRow>
@@ -662,6 +696,7 @@ const AdminWordsPage = () => {
                         aria-label={word.approved ? 'Revoke approval' : 'Mark as approved'}
                         onClick={() => toggleApproval(word)}
                         debugId={`${pageDebugId}-word-${word.id}-toggle-approval-button`}
+                        id={`${pageDebugId}-word-${word.id}-toggle-approval-button`}
                       >
                         {word.approved ? (
                           <Trash2 className="h-4 w-4" aria-hidden />
@@ -685,6 +720,7 @@ const AdminWordsPage = () => {
                             title="Edit entry"
                             aria-label="Edit entry"
                             debugId={`${pageDebugId}-word-${word.id}-edit-button`}
+                            id={`${pageDebugId}-word-${word.id}-edit-button`}
                           >
                             <PenSquare className="h-4 w-4" aria-hidden />
                           </Button>
@@ -801,6 +837,7 @@ const AdminWordsPage = () => {
                               type="submit"
                               disabled={updateMutation.isPending}
                               debugId={`${pageDebugId}-word-${word.id}-save-button`}
+                              id={`${pageDebugId}-word-${word.id}-save-button`}
                             >
                               Save changes
                             </Button>
@@ -809,6 +846,7 @@ const AdminWordsPage = () => {
                               variant="outline"
                               onClick={closeEditor}
                               debugId={`${pageDebugId}-word-${word.id}-cancel-button`}
+                              id={`${pageDebugId}-word-${word.id}-cancel-button`}
                             >
                               Cancel
                             </Button>
@@ -837,7 +875,7 @@ const AdminWordsPage = () => {
               </TableBody>
             </Table>
           </div>
-          <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+          <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between" id={ADMIN_PAGE_IDS.pagination}>
             <div className="text-sm text-muted-foreground">
               {totalWords
                 ? `Showing ${pageStart}–${pageEnd} of ${totalWords} words`
@@ -851,6 +889,7 @@ const AdminWordsPage = () => {
                 disabled={currentPage <= 1 || wordsQuery.isLoading}
                 className="rounded-2xl"
                 debugId={`${pageDebugId}-pagination-previous-button`}
+                id={`${pageDebugId}-pagination-previous-button`}
               >
                 Previous
               </Button>
@@ -865,15 +904,17 @@ const AdminWordsPage = () => {
                 }
                 className="rounded-2xl"
                 debugId={`${pageDebugId}-pagination-next-button`}
+                id={`${pageDebugId}-pagination-next-button`}
               >
                 Next
               </Button>
             </div>
           </div>
         </CardContent>
-      </Card>
+        </Card>
+      </div>
+      </AppShell>
     </div>
-    </AppShell>
   );
 };
 

--- a/client/src/pages/analytics.tsx
+++ b/client/src/pages/analytics.tsx
@@ -62,6 +62,20 @@ function SessionProgressBar({ value, completed, target, debugId }: SessionProgre
   );
 }
 
+const ANALYTICS_IDS = {
+  page: "analytics-page",
+  headerSection: "analytics-header",
+  backButton: "analytics-back-button",
+  avatar: "analytics-avatar",
+  dashboardGrid: "analytics-dashboard-grid",
+  dashboardColumn: "analytics-dashboard-column",
+  overviewPanel: "analytics-overview-panel",
+  attemptsPanel: "analytics-attempts-panel",
+  accordionPanel: "analytics-accordion",
+  tabsPanel: "analytics-tabs",
+  reviewHistoryLink: "analytics-review-history-link",
+} as const;
+
 export default function Analytics() {
   const { settings } = usePracticeSettings();
   const progress = useMemo(() => loadPracticeProgress(), []);
@@ -101,7 +115,7 @@ export default function Analytics() {
   const historyCount = answerHistory.length;
 
   const overviewPanel = (
-    <div className="space-y-4">
+    <div className="space-y-4" id={ANALYTICS_IDS.overviewPanel}>
       <ProgressDisplay
         progress={progress}
         taskType={activeTaskType}
@@ -122,7 +136,10 @@ export default function Analytics() {
   );
 
   const attemptsPanel = (
-    <div className="rounded-2xl border border-border/60 bg-muted/30 p-5 shadow-inner shadow-primary/5">
+    <div
+      className="rounded-2xl border border-border/60 bg-muted/30 p-5 shadow-inner shadow-primary/5"
+      id={ANALYTICS_IDS.attemptsPanel}
+    >
       <div className="flex items-center justify-between text-sm font-medium text-muted-foreground">
         Session recap
         <span className="rounded-full border border-primary/30 bg-primary/10 px-3 py-1 text-xs font-medium text-primary">
@@ -145,7 +162,11 @@ export default function Analytics() {
               ? `${summary.total} attempt${summary.total === 1 ? "" : "s"} recorded · ${summary.accuracy}% accuracy`
               : "Take your first attempt to unlock personalised insights."}
           </p>
-          <Link href="/answers" className="inline-flex items-center text-sm font-medium text-primary">
+          <Link
+            href="/answers"
+            className="inline-flex items-center text-sm font-medium text-primary"
+            id={ANALYTICS_IDS.reviewHistoryLink}
+          >
             Review history
             <span aria-hidden className="ml-2">
               →
@@ -180,98 +201,113 @@ export default function Analytics() {
   );
 
   return (
-    <AppShell
-      sidebar={sidebar}
-      mobileNav={<MobileNavBar items={navigationItems} />}
-    >
-      <section className="space-y-4 rounded-3xl border border-border/60 bg-card/85 p-6 shadow-soft shadow-primary/5">
-        <div className="space-y-1">
-          <p className="text-[11px] font-semibold uppercase tracking-[0.22em] text-muted-foreground">Performance insights</p>
-          <h1 className="flex items-center gap-2 text-2xl font-semibold text-foreground">
-            <BarChart3 className="h-6 w-6 text-primary" aria-hidden />
-            Analytics dashboard
-          </h1>
-          <p className="max-w-2xl text-sm text-muted-foreground">
-            Dive into your progress trends, identify tricky verbs, and celebrate your growth with responsive dashboards.
-          </p>
-        </div>
-        <div className="flex flex-wrap items-center justify-start gap-2 sm:justify-end">
-          <Link href="/">
-            <Button variant="secondary" className="rounded-2xl px-5">
-              Back to practice
-            </Button>
-          </Link>
-          <Avatar className="h-11 w-11 border border-border/60 shadow-sm">
-            <AvatarFallback className="bg-primary/10 text-sm font-semibold text-primary">LV</AvatarFallback>
-          </Avatar>
-        </div>
-      </section>
-      <div className="grid gap-6 xl:grid-cols-[minmax(0,2.4fr)_minmax(0,1.6fr)]">
-        <div className="space-y-6">
-          <AnalyticsDashboard />
-        </div>
-        <aside className="space-y-6">
-          <div className="rounded-3xl border border-border/60 bg-card/80 shadow-xl shadow-primary/5 lg:hidden">
-            <div className="flex flex-wrap items-center justify-between gap-3 border-b border-border/60 px-5 py-4">
-              <div>
-                <p className="text-sm font-medium text-muted-foreground">Performance center</p>
-                <p className="text-lg font-semibold text-foreground">{summary.accuracy}% accuracy</p>
-                <p className="text-sm text-muted-foreground">
-                  Tracking {historyCount} logged attempt{historyCount === 1 ? "" : "s"}
-                </p>
-              </div>
-            </div>
-            <Accordion type="single" collapsible defaultValue="overview" className="divide-y divide-border/60">
-              <AccordionItem value="overview">
-                <AccordionTrigger className="px-5 py-3 text-sm font-medium text-muted-foreground">
-                  Overview
-                </AccordionTrigger>
-                <AccordionContent className="space-y-4 px-5 pb-5">{overviewPanel}</AccordionContent>
-              </AccordionItem>
-              <AccordionItem value="attempts">
-                <AccordionTrigger className="px-5 py-3 text-sm font-medium text-muted-foreground">
-                  Attempts
-                </AccordionTrigger>
-                <AccordionContent className="space-y-4 px-5 pb-5">{attemptsPanel}</AccordionContent>
-              </AccordionItem>
-            </Accordion>
+    <div id={ANALYTICS_IDS.page}>
+      <AppShell
+        sidebar={sidebar}
+        mobileNav={<MobileNavBar items={navigationItems} />}
+      >
+        <section
+          className="space-y-4 rounded-3xl border border-border/60 bg-card/85 p-6 shadow-soft shadow-primary/5"
+          id={ANALYTICS_IDS.headerSection}
+        >
+          <div className="space-y-1">
+            <p className="text-[11px] font-semibold uppercase tracking-[0.22em] text-muted-foreground">Performance insights</p>
+            <h1 className="flex items-center gap-2 text-2xl font-semibold text-foreground">
+              <BarChart3 className="h-6 w-6 text-primary" aria-hidden />
+              Analytics dashboard
+            </h1>
+            <p className="max-w-2xl text-sm text-muted-foreground">
+              Dive into your progress trends, identify tricky verbs, and celebrate your growth with responsive dashboards.
+            </p>
           </div>
-
-          <Tabs defaultValue="overview" className="hidden w-full rounded-3xl border border-border/60 bg-card/80 shadow-xl shadow-primary/5 lg:block">
-            <div className="flex flex-wrap items-center justify-between gap-3 border-b border-border/60 px-6 py-4">
-              <div>
-                <p className="text-sm font-medium text-muted-foreground">Performance center</p>
-                <p className="text-lg font-semibold text-foreground">{summary.accuracy}% accuracy</p>
-                <p className="text-sm text-muted-foreground">
-                  Tracking {historyCount} logged attempt{historyCount === 1 ? "" : "s"}
-                </p>
+          <div className="flex flex-wrap items-center justify-start gap-2 sm:justify-end">
+            <Link href="/" id={ANALYTICS_IDS.backButton}>
+              <Button variant="secondary" className="rounded-2xl px-5">
+                Back to practice
+              </Button>
+            </Link>
+            <Avatar className="h-11 w-11 border border-border/60 shadow-sm" id={ANALYTICS_IDS.avatar}>
+              <AvatarFallback className="bg-primary/10 text-sm font-semibold text-primary">LV</AvatarFallback>
+            </Avatar>
+          </div>
+        </section>
+        <div
+          className="grid gap-6 xl:grid-cols-[minmax(0,2.4fr)_minmax(0,1.6fr)]"
+          id={ANALYTICS_IDS.dashboardGrid}
+        >
+          <div className="space-y-6" id={ANALYTICS_IDS.dashboardColumn}>
+            <AnalyticsDashboard />
+          </div>
+          <aside className="space-y-6">
+            <div
+              className="rounded-3xl border border-border/60 bg-card/80 shadow-xl shadow-primary/5 lg:hidden"
+              id={ANALYTICS_IDS.accordionPanel}
+            >
+              <div className="flex flex-wrap items-center justify-between gap-3 border-b border-border/60 px-5 py-4">
+                <div>
+                  <p className="text-sm font-medium text-muted-foreground">Performance center</p>
+                  <p className="text-lg font-semibold text-foreground">{summary.accuracy}% accuracy</p>
+                  <p className="text-sm text-muted-foreground">
+                    Tracking {historyCount} logged attempt{historyCount === 1 ? "" : "s"}
+                  </p>
+                </div>
               </div>
-              <TabsList className="flex rounded-full bg-muted/40 p-1">
-                <TabsTrigger
-                  value="overview"
-                  className="rounded-full px-3 py-1 text-sm font-medium text-muted-foreground transition data-[state=active]:bg-primary data-[state=active]:text-primary-foreground"
-                >
-                  Overview
-                </TabsTrigger>
-                <TabsTrigger
-                  value="attempts"
-                  className="rounded-full px-3 py-1 text-sm font-medium text-muted-foreground transition data-[state=active]:bg-primary data-[state=active]:text-primary-foreground"
-                >
-                  Attempts
-                </TabsTrigger>
-              </TabsList>
+              <Accordion type="single" collapsible defaultValue="overview" className="divide-y divide-border/60">
+                <AccordionItem value="overview">
+                  <AccordionTrigger className="px-5 py-3 text-sm font-medium text-muted-foreground">
+                    Overview
+                  </AccordionTrigger>
+                  <AccordionContent className="space-y-4 px-5 pb-5">{overviewPanel}</AccordionContent>
+                </AccordionItem>
+                <AccordionItem value="attempts">
+                  <AccordionTrigger className="px-5 py-3 text-sm font-medium text-muted-foreground">
+                    Attempts
+                  </AccordionTrigger>
+                  <AccordionContent className="space-y-4 px-5 pb-5">{attemptsPanel}</AccordionContent>
+                </AccordionItem>
+              </Accordion>
             </div>
 
-            <TabsContent value="overview" className="space-y-4 px-6 py-6">
-              {overviewPanel}
-            </TabsContent>
+            <Tabs
+              defaultValue="overview"
+              className="hidden w-full rounded-3xl border border-border/60 bg-card/80 shadow-xl shadow-primary/5 lg:block"
+              id={ANALYTICS_IDS.tabsPanel}
+            >
+              <div className="flex flex-wrap items-center justify-between gap-3 border-b border-border/60 px-6 py-4">
+                <div>
+                  <p className="text-sm font-medium text-muted-foreground">Performance center</p>
+                  <p className="text-lg font-semibold text-foreground">{summary.accuracy}% accuracy</p>
+                  <p className="text-sm text-muted-foreground">
+                    Tracking {historyCount} logged attempt{historyCount === 1 ? "" : "s"}
+                  </p>
+                </div>
+                <TabsList className="flex rounded-full bg-muted/40 p-1">
+                  <TabsTrigger
+                    value="overview"
+                    className="rounded-full px-3 py-1 text-sm font-medium text-muted-foreground transition data-[state=active]:bg-primary data-[state=active]:text-primary-foreground"
+                  >
+                    Overview
+                  </TabsTrigger>
+                  <TabsTrigger
+                    value="attempts"
+                    className="rounded-full px-3 py-1 text-sm font-medium text-muted-foreground transition data-[state=active]:bg-primary data-[state=active]:text-primary-foreground"
+                  >
+                    Attempts
+                  </TabsTrigger>
+                </TabsList>
+              </div>
 
-            <TabsContent value="attempts" className="space-y-4 px-6 py-6">
-              {attemptsPanel}
-            </TabsContent>
-          </Tabs>
-        </aside>
-      </div>
-    </AppShell>
+              <TabsContent value="overview" className="space-y-4 px-6 py-6">
+                {overviewPanel}
+              </TabsContent>
+
+              <TabsContent value="attempts" className="space-y-4 px-6 py-6">
+                {attemptsPanel}
+              </TabsContent>
+            </Tabs>
+          </aside>
+        </div>
+      </AppShell>
+    </div>
   );
 }

--- a/client/src/pages/answer-history.tsx
+++ b/client/src/pages/answer-history.tsx
@@ -23,6 +23,20 @@ type ResultFilter = "all" | "correct" | "incorrect";
 const LEVEL_FILTERS: LevelFilter[] = ["all", "A1", "A2", "B1", "B2", "C1", "C2"];
 const RESULT_FILTERS: ResultFilter[] = ["all", "correct", "incorrect"];
 
+const ANSWER_HISTORY_IDS = {
+  page: "answer-history-page",
+  content: "answer-history-content",
+  headerSection: "answer-history-header",
+  statsSection: "answer-history-stats",
+  filtersSection: "answer-history-filters",
+  loadErrorAlert: "answer-history-load-error",
+  skeletonSection: "answer-history-skeleton",
+  panelSection: "answer-history-panel",
+  backButton: "answer-history-back-button",
+  clearButton: "answer-history-clear-button",
+  retryButton: "answer-history-retry-button",
+} as const;
+
 function mergeAnswerLists(primary: AnsweredQuestion[], secondary: AnsweredQuestion[]): AnsweredQuestion[] {
   const seen = new Set<string>();
   const combined: AnsweredQuestion[] = [];
@@ -211,7 +225,10 @@ export default function AnswerHistoryPage() {
   );
 
   const filterControls = (
-    <div className="grid gap-6 rounded-3xl border border-border/60 bg-card/80 p-6 shadow-lg shadow-primary/5">
+    <section
+      className="grid gap-6 rounded-3xl border border-border/60 bg-card/80 p-6 shadow-lg shadow-primary/5"
+      id={ANSWER_HISTORY_IDS.filtersSection}
+    >
       <div>
         <p className="text-xs font-semibold uppercase tracking-[0.22em] text-muted-foreground">Filter by level</p>
         <div className="mt-3 flex flex-wrap gap-2">
@@ -268,48 +285,53 @@ export default function AnswerHistoryPage() {
           </Button>
         </div>
       ) : null}
-    </div>
+    </section>
   );
 
   return (
-    <AppShell
-      sidebar={sidebar}
-      mobileNav={<MobileNavBar items={navigationItems} />}
-    >
-      <div className="space-y-6">
-        <section className="flex flex-col gap-3 rounded-3xl border border-border/60 bg-card/85 p-6 shadow-soft shadow-primary/5 sm:flex-row sm:items-center sm:justify-between">
-          <div className="space-y-1">
-            <h1 className="inline-flex items-center gap-2 text-sm font-semibold uppercase tracking-[0.22em] text-foreground">
-              <History className="h-4 w-4" aria-hidden />
-              Answer history
-            </h1>
-          </div>
-          <div className="flex flex-wrap items-center justify-end gap-2">
-            <Link href="/">
-              <Button variant="secondary" className="rounded-2xl px-5">
-                <ArrowLeft className="mr-2 h-4 w-4" aria-hidden />
-                Back to practice
+    <div id={ANSWER_HISTORY_IDS.page}>
+      <AppShell
+        sidebar={sidebar}
+        mobileNav={<MobileNavBar items={navigationItems} />}
+      >
+        <div className="space-y-6" id={ANSWER_HISTORY_IDS.content}>
+          <section
+            className="flex flex-col gap-3 rounded-3xl border border-border/60 bg-card/85 p-6 shadow-soft shadow-primary/5 sm:flex-row sm:items-center sm:justify-between"
+            id={ANSWER_HISTORY_IDS.headerSection}
+          >
+            <div className="space-y-1">
+              <h1 className="inline-flex items-center gap-2 text-sm font-semibold uppercase tracking-[0.22em] text-foreground">
+                <History className="h-4 w-4" aria-hidden />
+                Answer history
+              </h1>
+            </div>
+            <div className="flex flex-wrap items-center justify-end gap-2">
+              <Link href="/" id={ANSWER_HISTORY_IDS.backButton}>
+                <Button variant="secondary" className="rounded-2xl px-5" id={`${ANSWER_HISTORY_IDS.backButton}-button`}>
+                  <ArrowLeft className="mr-2 h-4 w-4" aria-hidden />
+                  Back to practice
+                </Button>
+              </Link>
+              <Button
+                variant="outline"
+                onClick={handleClearHistory}
+                disabled={totalAnswers === 0 || isClearing || isLoading}
+                className="rounded-2xl px-5"
+                id={ANSWER_HISTORY_IDS.clearButton}
+              >
+                {isClearing ? (
+                  <Loader2 className="mr-2 h-4 w-4 animate-spin" aria-hidden />
+                ) : (
+                  <Trash2 className="mr-2 h-4 w-4" aria-hidden />
+                )}
+                {isClearing ? "Clearing…" : "Clear history"}
               </Button>
-            </Link>
-            <Button
-              variant="outline"
-              onClick={handleClearHistory}
-              disabled={totalAnswers === 0 || isClearing || isLoading}
-              className="rounded-2xl px-5"
-            >
-              {isClearing ? (
-                <Loader2 className="mr-2 h-4 w-4 animate-spin" aria-hidden />
-              ) : (
-                <Trash2 className="mr-2 h-4 w-4" aria-hidden />
-              )}
-              {isClearing ? "Clearing…" : "Clear history"}
-            </Button>
-          </div>
-        </section>
-        <section className="grid gap-4 md:grid-cols-3">
-          <div className="space-y-2 rounded-3xl border border-border/60 bg-card/85 p-5 shadow-soft shadow-primary/5">
-            <p className="text-xs font-semibold uppercase tracking-[0.22em] text-muted-foreground">Total attempts</p>
-            {showSkeletonStats ? (
+            </div>
+          </section>
+          <section className="grid gap-4 md:grid-cols-3" id={ANSWER_HISTORY_IDS.statsSection}>
+            <div className="space-y-2 rounded-3xl border border-border/60 bg-card/85 p-5 shadow-soft shadow-primary/5">
+              <p className="text-xs font-semibold uppercase tracking-[0.22em] text-muted-foreground">Total attempts</p>
+              {showSkeletonStats ? (
               <Skeleton className="h-8 w-16" />
             ) : (
               <p className="text-3xl font-semibold text-foreground">{totalAnswers}</p>
@@ -335,51 +357,59 @@ export default function AnswerHistoryPage() {
               <p className="text-3xl font-semibold text-foreground">{formattedAverageTime}</p>
             )}
             <p className="text-xs text-muted-foreground">Based on recent answers</p>
-          </div>
-        </section>
-        {filterControls}
-        {loadError ? (
-          <Alert variant="destructive" className="rounded-3xl border border-destructive/40 bg-destructive/10">
-            <AlertTitle>Unable to refresh history</AlertTitle>
-            <AlertDescription className="flex flex-wrap items-center justify-between gap-3">
-              <span>{loadError}</span>
-              <Button
-                type="button"
-                variant="outline"
-                size="sm"
-                className="rounded-xl px-3 text-xs font-semibold uppercase tracking-[0.22em]"
-                onClick={handleRetryLoad}
-                disabled={isLoading}
-              >
-                Retry
-              </Button>
-            </AlertDescription>
-          </Alert>
-        ) : null}
-        {isLoading && history.length === 0 ? (
-          <div className="space-y-4">
-            {Array.from({ length: 3 }).map((_, index) => (
-              <div
-                key={index}
-                className="rounded-3xl border border-border/60 bg-card/80 p-5 shadow-soft shadow-primary/5"
-              >
-                <Skeleton className="h-5 w-32" />
-                <Skeleton className="mt-4 h-4 w-full" />
-                <Skeleton className="mt-2 h-4 w-3/4" />
-                <Skeleton className="mt-2 h-4 w-1/2" />
-              </div>
-            ))}
-          </div>
-        ) : (
-          <AnsweredQuestionsPanel
-            history={filteredHistory}
-            title="Detailed answer log"
-            description="Track your responses across every practice session. Each entry includes the correct forms and contextual examples so you can revise with confidence."
-            emptyStateMessage="Once you start practicing, your answers will appear here with all the details you need to review."
-          />
-        )}
-      </div>
-    </AppShell>
+            </div>
+          </section>
+          {filterControls}
+          {loadError ? (
+            <Alert
+              variant="destructive"
+              className="rounded-3xl border border-destructive/40 bg-destructive/10"
+              id={ANSWER_HISTORY_IDS.loadErrorAlert}
+            >
+              <AlertTitle>Unable to refresh history</AlertTitle>
+              <AlertDescription className="flex flex-wrap items-center justify-between gap-3">
+                <span>{loadError}</span>
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="sm"
+                  className="rounded-xl px-3 text-xs font-semibold uppercase tracking-[0.22em]"
+                  onClick={handleRetryLoad}
+                  disabled={isLoading}
+                  id={ANSWER_HISTORY_IDS.retryButton}
+                >
+                  Retry
+                </Button>
+              </AlertDescription>
+            </Alert>
+          ) : null}
+          {isLoading && history.length === 0 ? (
+            <div className="space-y-4" id={ANSWER_HISTORY_IDS.skeletonSection}>
+              {Array.from({ length: 3 }).map((_, index) => (
+                <div
+                  key={index}
+                  className="rounded-3xl border border-border/60 bg-card/80 p-5 shadow-soft shadow-primary/5"
+                >
+                  <Skeleton className="h-5 w-32" />
+                  <Skeleton className="mt-4 h-4 w-full" />
+                  <Skeleton className="mt-2 h-4 w-3/4" />
+                  <Skeleton className="mt-2 h-4 w-1/2" />
+                </div>
+              ))}
+            </div>
+          ) : (
+            <div id={ANSWER_HISTORY_IDS.panelSection}>
+              <AnsweredQuestionsPanel
+                history={filteredHistory}
+                title="Detailed answer log"
+                description="Track your responses across every practice session. Each entry includes the correct forms and contextual examples so you can revise with confidence."
+                emptyStateMessage="Once you start practicing, your answers will appear here with all the details you need to review."
+              />
+            </div>
+          )}
+        </div>
+      </AppShell>
+    </div>
   );
 }
 

--- a/client/src/pages/home.tsx
+++ b/client/src/pages/home.tsx
@@ -55,6 +55,23 @@ import {
 const MIN_QUEUE_THRESHOLD = 5;
 const FETCH_LIMIT = 15;
 
+const HOME_SECTION_IDS = {
+  page: 'home-page',
+  content: 'home-page-content',
+  practiceSection: 'home-practice-section',
+  modeSwitcher: 'home-practice-mode-switcher',
+  cardContainer: 'home-practice-card-container',
+  loadingState: 'home-practice-loading-state',
+  activeCardWrapper: 'home-active-practice-card',
+  emptyState: 'home-practice-empty-state',
+  fetchError: 'home-practice-fetch-error',
+  reloadButton: 'home-reload-button',
+  retryButton: 'home-retry-button',
+  skipButton: 'home-skip-button',
+  reviewHistoryLink: 'home-review-history-link',
+  reviewHistoryButton: 'home-review-history-button',
+} as const;
+
 function mergeTaskLists(lists: PracticeTask[][], limit: number): PracticeTask[] {
   const queues = lists.map((list) => [...list]);
   const result: PracticeTask[] = [];
@@ -402,15 +419,22 @@ export default function Home() {
     </div>
   );
   return (
-    <AppShell
-      sidebar={sidebar}
-      mobileNav={<MobileNavBar items={navigationItems} />}
-      debugId="home-app-shell"
-    >
-      <div className="space-y-6">
-        <section className="flex min-h-[540px] flex-col gap-6 rounded-3xl border border-border/50 bg-card/80 p-6 shadow-xl shadow-primary/10">
+    <div id={HOME_SECTION_IDS.page}>
+      <AppShell
+        sidebar={sidebar}
+        mobileNav={<MobileNavBar items={navigationItems} />}
+        debugId="home-app-shell"
+      >
+      <div className="space-y-6" id={HOME_SECTION_IDS.content}>
+        <section
+          className="flex min-h-[540px] flex-col gap-6 rounded-3xl border border-border/50 bg-card/80 p-6 shadow-xl shadow-primary/10"
+          id={HOME_SECTION_IDS.practiceSection}
+        >
           <div className="space-y-6 text-left">
-            <div className="flex flex-wrap items-center justify-between gap-3">
+            <div
+              className="flex flex-wrap items-center justify-between gap-3"
+              id={HOME_SECTION_IDS.modeSwitcher}
+            >
               <PracticeModeSwitcher
                 debugId="topbar-mode-switcher"
                 scope={scope}
@@ -424,26 +448,38 @@ export default function Home() {
           </div>
 
           <div className="flex flex-1 flex-col gap-6">
-            <div className="w-full xl:max-w-none" data-testid="practice-card-container">
+            <div
+              className="w-full xl:max-w-none"
+              data-testid="practice-card-container"
+              id={HOME_SECTION_IDS.cardContainer}
+            >
               {isInitialLoading ? (
-                <div className="flex h-[340px] items-center justify-center rounded-[28px] border border-dashed border-border/60 bg-background/70 shadow-2xl shadow-primary/15">
+                <div
+                  className="flex h-[340px] items-center justify-center rounded-[28px] border border-dashed border-border/60 bg-background/70 shadow-2xl shadow-primary/15"
+                  id={HOME_SECTION_IDS.loadingState}
+                >
                   <Loader2 className="h-8 w-8 animate-spin text-primary" />
                 </div>
               ) : activeTask ? (
-                <PracticeCard
-                  key={activeTask.taskId}
-                  task={activeTask}
-                  settings={settings}
-                  onResult={handleTaskResult}
-                  isLoadingNext={isFetchingTasks && session.queue.length === 0}
-                  debugId="home-practice-card"
-                  sessionProgress={{
-                    completed: sessionCompleted,
-                    target: milestoneTarget,
-                  }}
-                />
+                <div id={HOME_SECTION_IDS.activeCardWrapper}>
+                  <PracticeCard
+                    key={activeTask.taskId}
+                    task={activeTask}
+                    settings={settings}
+                    onResult={handleTaskResult}
+                    isLoadingNext={isFetchingTasks && session.queue.length === 0}
+                    debugId="home-practice-card"
+                    sessionProgress={{
+                      completed: sessionCompleted,
+                      target: milestoneTarget,
+                    }}
+                  />
+                </div>
               ) : (
-                <div className="flex h-[340px] flex-col items-center justify-center gap-3 rounded-[28px] border border-border/60 bg-background/70 text-center shadow-2xl shadow-primary/10">
+                <div
+                  className="flex h-[340px] flex-col items-center justify-center gap-3 rounded-[28px] border border-border/60 bg-background/70 text-center shadow-2xl shadow-primary/10"
+                  id={HOME_SECTION_IDS.emptyState}
+                >
                   <p className="text-sm text-muted-foreground">
                     No tasks are queued right now. Adjust your practice scope or reload to fetch fresh prompts.
                   </p>
@@ -455,6 +491,7 @@ export default function Home() {
                       setFetchError(null);
                       void fetchAndEnqueueTasks({ replace: true });
                     }}
+                    id={HOME_SECTION_IDS.reloadButton}
                   >
                     Reload tasks
                   </Button>
@@ -464,6 +501,7 @@ export default function Home() {
                 <div
                   className="mt-4 rounded-2xl border border-destructive/40 bg-destructive/5 px-4 py-4 text-sm text-destructive"
                   role="alert"
+                  id={HOME_SECTION_IDS.fetchError}
                 >
                   <p className="text-center font-medium">
                     We couldn't load new tasks. Check your connection or adjust your practice scope, then try again.
@@ -480,6 +518,7 @@ export default function Home() {
                         setFetchError(null);
                         void fetchAndEnqueueTasks({ replace: true });
                       }}
+                      id={HOME_SECTION_IDS.retryButton}
                     >
                       Retry loading
                     </Button>
@@ -488,18 +527,24 @@ export default function Home() {
               )}
             </div>
           </div>
-          <div className="flex w-full flex-col gap-3 sm:flex-row">
+          <div className="flex w-full flex-col gap-3 sm:flex-row" id={HOME_SECTION_IDS.reviewHistoryLink}>
             <Button
               variant="secondary"
               className="flex-1 rounded-2xl text-base sm:h-12"
               onClick={handleSkipTask}
               disabled={!activeTask}
               debugId="practice-skip-button"
+              id={HOME_SECTION_IDS.skipButton}
             >
               Skip to next
             </Button>
             <Link href="/answers" className="flex-1">
-              <Button variant="secondary" className="w-full rounded-2xl text-base sm:h-12" debugId="practice-review-history-button">
+              <Button
+                variant="secondary"
+                className="w-full rounded-2xl text-base sm:h-12"
+                debugId="practice-review-history-button"
+                id={HOME_SECTION_IDS.reviewHistoryButton}
+              >
                 <History className="mr-2 h-4 w-4" aria-hidden />
                 Review answer history
               </Button>
@@ -507,6 +552,7 @@ export default function Home() {
           </div>
         </section>
       </div>
-    </AppShell>
+      </AppShell>
+    </div>
   );
 }

--- a/client/src/pages/not-found.tsx
+++ b/client/src/pages/not-found.tsx
@@ -3,16 +3,30 @@ import { AlertCircle, ArrowLeft } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Link } from "wouter";
 
+const NOT_FOUND_IDS = {
+  page: "not-found-page",
+  card: "not-found-card",
+  icon: "not-found-icon",
+  message: "not-found-message",
+  backButton: "not-found-back-button",
+} as const;
+
 export default function NotFound() {
   return (
-    <div className="flex min-h-screen w-full items-center justify-center bg-background px-4 py-12 sm:px-6 lg:px-8">
-      <Card className="mx-auto w-full max-w-lg border border-border bg-card shadow-sm">
+    <div
+      className="flex min-h-screen w-full items-center justify-center bg-background px-4 py-12 sm:px-6 lg:px-8"
+      id={NOT_FOUND_IDS.page}
+    >
+      <Card className="mx-auto w-full max-w-lg border border-border bg-card shadow-sm" id={NOT_FOUND_IDS.card}>
         <CardHeader className="space-y-4 text-center">
-          <div className="mx-auto flex h-16 w-16 items-center justify-center rounded-2xl bg-destructive/15">
+          <div
+            className="mx-auto flex h-16 w-16 items-center justify-center rounded-2xl bg-destructive/15"
+            id={NOT_FOUND_IDS.icon}
+          >
             <AlertCircle className="h-8 w-8 text-destructive" />
           </div>
           <CardTitle className="text-foreground">Page not found</CardTitle>
-          <CardDescription className="text-sm text-muted-foreground">
+          <CardDescription className="text-sm text-muted-foreground" id={NOT_FOUND_IDS.message}>
             We couldn&apos;t find the view you were looking for. It may not be wired into the router yet.
           </CardDescription>
         </CardHeader>
@@ -22,7 +36,7 @@ export default function NotFound() {
           </p>
           <div className="flex justify-center">
             <Link href="/">
-              <Button className="rounded-full px-6">
+              <Button className="rounded-full px-6" id={NOT_FOUND_IDS.backButton}>
                 <ArrowLeft className="mr-2 h-4 w-4" />
                 Back to practice
               </Button>

--- a/client/src/pages/ui-testbed.tsx
+++ b/client/src/pages/ui-testbed.tsx
@@ -19,6 +19,19 @@ import { Switch } from "@/components/ui/switch";
 import { Toggle } from "@/components/ui/toggle";
 import { Button } from "@/components/ui/button";
 
+const UI_TESTBED_IDS = {
+  page: "ui-testbed-page",
+  dialogSection: "ui-testbed-dialog-section",
+  popoverSection: "ui-testbed-popover-section",
+  dropdownSection: "ui-testbed-dropdown-section",
+  controlsSection: "ui-testbed-controls-section",
+  dialogTrigger: "ui-testbed-dialog-trigger",
+  popoverTrigger: "ui-testbed-popover-trigger",
+  menuTrigger: "ui-testbed-menu-trigger",
+  switchControl: "ui-testbed-switch-control",
+  toggleControl: "ui-testbed-toggle-control",
+} as const;
+
 export default function UITestbedPage() {
   const [dialogOpen, setDialogOpen] = useState(false);
   const [selection, setSelection] = useState("none");
@@ -26,12 +39,18 @@ export default function UITestbedPage() {
   const [toggleOn, setToggleOn] = useState(false);
 
   return (
-    <div className="min-h-screen space-y-10 bg-background p-10 text-foreground" data-testid="ui-testbed">
-      <section className="space-y-4" data-testid="dialog-section">
+    <div
+      className="min-h-screen space-y-10 bg-background p-10 text-foreground"
+      data-testid="ui-testbed"
+      id={UI_TESTBED_IDS.page}
+    >
+      <section className="space-y-4" data-testid="dialog-section" id={UI_TESTBED_IDS.dialogSection}>
         <h1 className="text-2xl font-semibold">Dialog</h1>
         <Dialog open={dialogOpen} onOpenChange={setDialogOpen}>
           <DialogTrigger asChild>
-            <Button data-testid="dialog-trigger">Launch dialog</Button>
+            <Button data-testid="dialog-trigger" id={UI_TESTBED_IDS.dialogTrigger}>
+              Launch dialog
+            </Button>
           </DialogTrigger>
           <DialogContent
             data-testid="dialog-content"
@@ -51,11 +70,13 @@ export default function UITestbedPage() {
         </Dialog>
       </section>
 
-      <section className="space-y-4" data-testid="popover-section">
+      <section className="space-y-4" data-testid="popover-section" id={UI_TESTBED_IDS.popoverSection}>
         <h2 className="text-2xl font-semibold">Popover</h2>
         <Popover>
           <PopoverTrigger asChild>
-            <Button data-testid="popover-trigger">Show shortcuts</Button>
+            <Button data-testid="popover-trigger" id={UI_TESTBED_IDS.popoverTrigger}>
+              Show shortcuts
+            </Button>
           </PopoverTrigger>
           <PopoverContent
             data-testid="popover-content"
@@ -76,11 +97,13 @@ export default function UITestbedPage() {
         </Popover>
       </section>
 
-      <section className="space-y-4" data-testid="dropdown-section">
+      <section className="space-y-4" data-testid="dropdown-section" id={UI_TESTBED_IDS.dropdownSection}>
         <h2 className="text-2xl font-semibold">Dropdown menu</h2>
         <DropdownMenu>
           <DropdownMenuTrigger asChild>
-            <Button data-testid="menu-trigger">Menu</Button>
+            <Button data-testid="menu-trigger" id={UI_TESTBED_IDS.menuTrigger}>
+              Menu
+            </Button>
           </DropdownMenuTrigger>
           <DropdownMenuContent data-testid="menu-content">
             <DropdownMenuLabel>Account</DropdownMenuLabel>
@@ -93,7 +116,7 @@ export default function UITestbedPage() {
         <p data-testid="menu-selection">Last selection: {selection}</p>
       </section>
 
-      <section className="space-y-4" data-testid="controls-section">
+      <section className="space-y-4" data-testid="controls-section" id={UI_TESTBED_IDS.controlsSection}>
         <h2 className="text-2xl font-semibold">Controls</h2>
         <div className="flex items-center gap-6">
           <div className="flex items-center gap-3">
@@ -102,6 +125,7 @@ export default function UITestbedPage() {
               aria-label="Dark mode"
               checked={switchOn}
               onCheckedChange={setSwitchOn}
+              id={UI_TESTBED_IDS.switchControl}
             />
             <span>{switchOn ? "Enabled" : "Disabled"}</span>
           </div>
@@ -111,6 +135,7 @@ export default function UITestbedPage() {
               aria-label="Notifications"
               pressed={toggleOn}
               onPressedChange={setToggleOn}
+              id={UI_TESTBED_IDS.toggleControl}
             >
               Notifications
             </Toggle>


### PR DESCRIPTION
## Summary
- add stable HTML identifiers to the home, answer history, analytics, admin, not found, and UI testbed pages
- expose IDs on key sections and controls to simplify DOM targeting and automation

## Testing
- npm run check
- npm test
- npm run test:e2e

------
https://chatgpt.com/codex/tasks/task_e_68f1e77e4df08320bcef14dcaa606c56