### PR TITLE
Fix answer history labels for non-verb tasks

### DIFF
--- a/client/src/components/answered-questions-panel.tsx
+++ b/client/src/components/answered-questions-panel.tsx
@@ -1,6 +1,7 @@
 import { Badge } from "@/components/ui/badge";
 import { cn } from "@/lib/utils";
 import type { PracticeMode } from "@/lib/types";
+import { getTaskTypeLabel } from "@/lib/task-metadata";
 import type { AnsweredQuestion } from "@/lib/answer-history";
 import type { AnswerHistoryLexemeSnapshot } from "@shared";
 import { derivePromptLemmaFromEntry } from "@/lib/prompt-lemma";
@@ -110,7 +111,7 @@ export function AnsweredQuestionsPanel({
                     auxiliary: verb.auxiliary,
                   } satisfies AnswerHistoryLexemeSnapshot)
                 : undefined);
-            const mode = item.mode ?? item.legacyVerb?.mode ?? "präteritum";
+            const mode = item.mode ?? item.legacyVerb?.mode;
             const level = item.level ?? item.cefrLevel ?? "A1";
             const prompt = item.prompt ?? item.promptSummary;
             const attempted = item.attemptedAnswer ?? (typeof item.submittedResponse === "string" ? item.submittedResponse : "");
@@ -155,7 +156,7 @@ export function AnsweredQuestionsPanel({
                       {item.result === "correct" ? "Correct" : "Incorrect"}
                     </Badge>
                     <span className="text-xs font-semibold uppercase tracking-[0.22em] text-muted-foreground">
-                      {MODE_LABELS[mode as PracticeMode] ?? mode}
+                      {mode ? MODE_LABELS[mode] ?? mode : getTaskTypeLabel(item.taskType)}
                     </span>
                     <span className="text-xs text-muted-foreground">Level {level}</span>
                     <span className="text-xs text-muted-foreground">Answered at {answeredTime}</span>


### PR DESCRIPTION
## Summary
- show the task type label in answer history when a practice mode is not available
- reuse existing task metadata so adjective and noun entries no longer display the Präteritum label

## Testing
- npm test
- npm run check

## UI/UX Checklist
- [x] Practice box remains dominant with header height within limits (unchanged)
- [x] Practice inputs/buttons stay full-width and ≥44px tall (unchanged)
- [x] Typography hierarchy remains consistent (no size changes)
- [x] All colors and spacing continue to use design tokens (no style updates)
- [x] Components still use shared UI primitives (no new components added)
- [x] Focus rings, hit areas, and accessible labels are intact (no interaction changes)
- [x] Light/dark themes render the same as before (text-only update)
- [x] Z-index usage unchanged (no layering updates)
- [x] Analytics/secondary metrics remain off the primary path (unchanged)
- [x] Keyboard interaction and reduced motion preferences unaffected (no behavior changes)

------
https://chatgpt.com/codex/tasks/task_e_68f2058843a88320b1857e7a43b376d8