### PR TITLE
Normalize Kaikki POS aliases for enrichment lookups

### DIFF
--- a/tests/enrichment/providers.test.ts
+++ b/tests/enrichment/providers.test.ts
@@ -221,7 +221,7 @@ describe('lookupWiktextract', () => {
   it('extracts comparative and superlative forms for adjectives', async () => {
     const germanEntry = {
       lang: 'German',
-      pos: 'adjective',
+      pos: 'adj.',
       word: 'schnell',
       forms: [
         { form: 'schneller', tags: ['comparative'] },
@@ -263,6 +263,23 @@ describe('lookupWiktextract', () => {
     expect(result?.posLabel).toBe('prep');
     expect(result?.posTags).toEqual(expect.arrayContaining(['directional']));
     expect(result?.posNotes).toEqual(expect.arrayContaining(['two-way prepositions']));
+  });
+
+  it('handles dotted Kaikki POS abbreviations when matching entries', async () => {
+    const germanEntry = {
+      lang: 'German',
+      pos: 'Präp.',
+      word: 'auf',
+      categories: ['German Wechselpräpositionen'],
+    };
+
+    mockedFetch.mockResolvedValueOnce(createResponse(`${JSON.stringify(germanEntry)}\n`));
+
+    const result = await lookupWiktextract('auf', 'Präp');
+
+    expect(result).not.toBeNull();
+    expect(result?.posLabel).toBe('Präp.');
+    expect(result?.prepositionAttributes?.cases).toEqual(['Akkusativ', 'Dativ']);
   });
 
   it('collects POS tags and usage notes for verbs when available', async () => {


### PR DESCRIPTION
## Summary
- expand Kaikki part-of-speech alias resolution to strip punctuation, normalise umlauts, and map form labels for all stored POS values
- add test coverage to ensure adjective and preposition enrichments work when Kaikki returns dotted POS abbreviations

## Testing
- npm run test -- tests/enrichment/providers.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68f27ae75cf88320bb6f8b1e6e0a3b6e