### PR TITLE
Handle additional comparative and superlative tags

### DIFF
--- a/scripts/enrichment/providers.ts
+++ b/scripts/enrichment/providers.ts
@@ -191,6 +191,24 @@ const CASE_TAGS = new Set([
   "vocative",
 ]);
 
+const COMPARATIVE_TAGS = new Set([
+  "comparative",
+  "comparative form",
+  "comparative-form",
+  "komparativ",
+  "komparativ form",
+  "komparativ-form",
+]);
+
+const SUPERLATIVE_TAGS = new Set([
+  "superlative",
+  "superlative form",
+  "superlative-form",
+  "superlativ",
+  "superlativ form",
+  "superlativ-form",
+]);
+
 const GENDER_MAP: Record<string, string> = {
   masculine: "der",
   feminine: "die",
@@ -925,10 +943,10 @@ function extractAdjectiveForms(entry: KaikkiEntry): WiktextractAdjectiveForms | 
     if (!formValue) continue;
     const tags = normaliseTags(form.tags);
     if (!tags.length) continue;
-    if (tags.includes("comparative")) {
+    if (tags.some((tag) => COMPARATIVE_TAGS.has(tag))) {
       comparatives.add(formValue);
     }
-    if (tags.includes("superlative")) {
+    if (tags.some((tag) => SUPERLATIVE_TAGS.has(tag))) {
       superlatives.add(formValue);
     }
     records.push({ form: formValue, tags });

--- a/tests/enrichment/providers.test.ts
+++ b/tests/enrichment/providers.test.ts
@@ -240,6 +240,25 @@ describe('lookupWiktextract', () => {
     );
   });
 
+  it('normalises comparative and superlative tags when parsing adjective forms', async () => {
+    const germanEntry = {
+      lang: 'German',
+      pos: 'adj',
+      word: 'gesund',
+      forms: [
+        { form: 'gesünder', tags: ['Komparativ'] },
+        { form: 'am gesündesten', tags: ['Superlativ'] },
+      ],
+    };
+
+    mockedFetch.mockResolvedValueOnce(createResponse(`${JSON.stringify(germanEntry)}\n`));
+
+    const result = await lookupWiktextract('gesund', 'Adj');
+
+    expect(result?.adjectiveForms?.comparatives).toEqual(['gesünder']);
+    expect(result?.adjectiveForms?.superlatives).toEqual(['am gesündesten']);
+  });
+
   it('extracts governed cases and notes for prepositions', async () => {
     const germanEntry = {
       lang: 'German',


### PR DESCRIPTION
## Summary
- recognise additional comparative and superlative tag spellings when parsing Kaikki adjective forms
- add coverage to ensure Komparativ/Superlativ tags are normalised when extracting adjective suggestions

## Testing
- npm test -- --runTestsByPath tests/enrichment/providers.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68f29bb3e924832082508f9dde72a888